### PR TITLE
Added QueryFiles to PostGres Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,28 @@ A small wrapper around pg/pg-promise to allow configuration from confit and
 tracking of start/finish/error on all queries.
 
 Supports the following methods from pg-promise: connect, any, none, one, oneOrNone, many, manyOrNone, result, tx, task
+
+## SQL Files
+
+This module also supports Query files from PGPromise.  In your config, pass in the directory of your query files.  You will then get an object that has the same structure as the folders you defined.
+
+If your folder structure looks like this:
+```
+ - feature
+    - create.sql
+    - getById.sql
+```
+
+You could make a DB call like this:
+```javascript
+async getById(featureId, locale) {
+    let returnFeature = null;
+    const sqlFiles = this.dbClient.sqlFiles;
+    const dbFeature = await this.dbClient.oneOrNone(sqlFiles.feature.getById, [featureId, locale]);
+    if (dbFeature) {
+      returnFeature = dbFeature.metadata;
+    }
+   return returnFeature;
+ }
+ ```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-postgres-client",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A configuration driven postgres client",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,13 @@ export default class PgClient extends EventEmitter {
     if (opts.interface) {
       this.interface = opts.interface.default || opts.interface;
     }
+    if (opts.sqlFilesDirectory) {
+      if (context && context.logger && context.logger.info) {
+        context.logger.info(`Creating SqlFiles for ${opts.sqlFilesDirectory}`);
+      }
+      this.sqlFiles = pgp.utils.enumSql(`${opts.sqlFilesDirectory}`, { recursive: true },
+        file => new pgp.QueryFile(file));
+    }
     this.options = Object.assign({}, opts);
     delete this.options.password;
   }
@@ -102,6 +109,9 @@ export default class PgClient extends EventEmitter {
       this.db = new (ClassConstructor)(this.pgClient, this.options);
     } else {
       this.db = this.pgClient;
+    }
+    if (this.sqlFiles) {
+      this.db.sqlFiles = this.sqlFiles;
     }
     usageCount += 1;
     return this.db;

--- a/tests/sqlFiles/testGroup1/testFile1.sql
+++ b/tests/sqlFiles/testGroup1/testFile1.sql
@@ -1,0 +1,1 @@
+SELECT 1 as one;

--- a/tests/test_connection.js
+++ b/tests/test_connection.js
@@ -18,3 +18,22 @@ tap.test('test_connection', async (t) => {
   await pg.stop();
   t.end();
 });
+
+tap.test('test query files', async(t) => {
+  const config = {
+    name: 'test-db',
+    hostname: process.env.PGHOST,
+    database: process.env.PGDATABASE || process.env.PGUSER || 'postgres',
+    username: process.env.PGUSER || 'postgres',
+    password: process.env.PGPASSWORD || '',
+    sqlFilesDirectory: '/data/tests/sqlFiles'
+  };
+  const pg = new PgClient(winston, config);
+  const db = await pg.start();
+  t.ok(db.sqlFiles.testGroup1.testFile1, 'Contains a test sql file');
+  const c = await db.one(db.sqlFiles.testGroup1.testFile1);
+  t.strictEquals(c.one, 1, 'Test query file should work.');
+  await pg.stop();
+  t.end();
+
+});

--- a/tests/test_connection.js
+++ b/tests/test_connection.js
@@ -26,7 +26,7 @@ tap.test('test query files', async (t) => {
     database: process.env.PGDATABASE || process.env.PGUSER || 'postgres',
     username: process.env.PGUSER || 'postgres',
     password: process.env.PGPASSWORD || '',
-    sqlFilesDirectory: '/data/tests/sqlFiles',
+    sqlFilesDirectory: `${__dirname}/sqlFiles`,
   };
   const pg = new PgClient(winston, config);
   const db = await pg.start();

--- a/tests/test_connection.js
+++ b/tests/test_connection.js
@@ -19,14 +19,14 @@ tap.test('test_connection', async (t) => {
   t.end();
 });
 
-tap.test('test query files', async(t) => {
+tap.test('test query files', async (t) => {
   const config = {
     name: 'test-db',
     hostname: process.env.PGHOST,
     database: process.env.PGDATABASE || process.env.PGUSER || 'postgres',
     username: process.env.PGUSER || 'postgres',
     password: process.env.PGPASSWORD || '',
-    sqlFilesDirectory: '/data/tests/sqlFiles'
+    sqlFilesDirectory: '/data/tests/sqlFiles',
   };
   const pg = new PgClient(winston, config);
   const db = await pg.start();
@@ -35,5 +35,4 @@ tap.test('test query files', async(t) => {
   t.strictEquals(c.one, 1, 'Test query file should work.');
   await pg.stop();
   t.end();
-
 });


### PR DESCRIPTION
In order to eliminate our issues with conflicting versions of PGPromise, we would like to add this functionality to the `configured-postgres-client` instead. 

We are finding we are basically copying this code from one project to the next, so if this functionality is in the configured postgres client we can just use it there.